### PR TITLE
reDirect Patch Improved Compatability

### DIFF
--- a/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
+++ b/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
@@ -46,14 +46,9 @@
 	@title = Orion MPCV 
 }
 
-@PART[Kertemis_Orion]
+
+@PART[DIRECT_Orion|Kertemis_Orion]
 {
-	%CrewCapacity = 4
-	%INTERNAL
-	{
-		%name = OrionIVA
-	}
-	
 	MODEL 
 	{
 		model = KertemisProgram/Parts/orion_rt/capsule_rt
@@ -167,7 +162,15 @@
 			transform = hatch_Circle.016_orion
 		}
 	}
+}
 
+@PART[Kertemis_Orion]
+{
+	%CrewCapacity = 4
+	%INTERNAL
+	{
+		%name = OrionIVA
+	}
 }
 
 @PART[DIRECT_orionServiceCone]:NEEDS[reDIRECT]

--- a/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
+++ b/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
@@ -39,7 +39,14 @@
 
 }
 
-@PART[DIRECT_Orion]:NEEDS[reDIRECT]
++PART[DIRECT_Orion]
+{
+	@name = Kertemis_Orion
+	@manufacturer = NASA
+	@title = Orion MPCV 
+}
+
+@PART[Kertemis_Orion]
 {
 	%CrewCapacity = 4
 	%INTERNAL

--- a/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
+++ b/GameData/KertemisProgram/Patches/reDIRECT_Patch.cfg
@@ -39,7 +39,7 @@
 
 }
 
-+PART[DIRECT_Orion]
++PART[DIRECT_Orion]:NEEDS[reDIRECT]
 {
 	@name = Kertemis_Orion
 	@manufacturer = NASA


### PR DESCRIPTION
Hello
To prevent save-game incompatibility, my pull request redirect_patch instead creates a new part, identical to the reDirect Orion Capulse which is then used as the basis for the node, IVA, B9PartSwitch, etc.
Means that existing craft can still have 6 crew but without the IVA.